### PR TITLE
docs: add AGC to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Correct or add to this list with a [pull request](https://github.com/jpivarski/P
 - [Work Queue](https://github.com/cooperative-computing-lab/cctools/tree/master/work_queue) ([website](http://ccl.cse.nd.edu/software/workqueue/)), a framework for building large distributed applications that span thousands of machines drawn from clusters, clouds, and grids: [@btovar](https://github.com/btovar)
 - [dask-awkward](https://github.com/dask-contrib/dask-awkward), native Dask collection for Awkward Arrays: [@agoose77](https://github.com/agoose77), [@lgray](https://github.com/lgray)
 - [hepdata_lib](https://github.com/HEPData/hepdata_lib), a library for getting your data into HEPData: [@clelange](https://github.com/clelange)
+- [Analysis Grand Challenge](https://github.com/iris-hep/analysis-grand-challenge), a project performing performing large scale end-to-end data analysis for HEP use cases: [@oshadura](https://github.com/oshadura), [@alexander-held](https://github.com/alexander-held)
 
 -----------------
 


### PR DESCRIPTION
Adding the Analysis Grand Challenge (AGC) project (https://agc.readthedocs.io/) to the list. This is not a library, but rather an integration project making use of or touching on many of the libraries in the list. Feel free to close if you want to purely focus this list on libraries.

cc @oshadura